### PR TITLE
Fix architecture review command

### DIFF
--- a/pr_agent/tools/pr_architecture_review.py
+++ b/pr_agent/tools/pr_architecture_review.py
@@ -23,8 +23,8 @@ class PRArchitectureReview(PRReviewer):
 
         super().__init__(pr_url, args=cleaned_args, ai_handler=ai_handler)
 
-        base_path = "ARHITECTURE.md"
-        branch = "master"
+        base_path = "ARCHITECTURE.md"
+        branch = get_settings().get("PR_HELP_DOCS.REPO_DEFAULT_BRANCH", "main")
 
         base_content = ""
         try:


### PR DESCRIPTION
## Summary
- fix the architecture file name
- read architecture file from configurable default branch

## Testing
- `pre-commit run --files pr_agent/tools/pr_architecture_review.py` *(fails: command not found)*
- `pytest -v tests/unittest` *(fails: ModuleNotFoundError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68722eaa478c8331b89b1629522431a3