### PR TITLE
Fix custom context in debug command

### DIFF
--- a/pr_agent/algo/utils.py
+++ b/pr_agent/algo/utils.py
@@ -710,6 +710,10 @@ def update_settings_from_args(args: List[str]) -> List[str]:
     if args:
         for arg in args:
             arg = arg.strip()
+            # allow command-specific flags like --custom-context to pass through
+            if arg.startswith('--custom-context='):
+                other_args.append(arg)
+                continue
             if arg.startswith('--'):
                 arg = arg.strip('-').strip()
                 vals = arg.split('=', 1)


### PR DESCRIPTION
## Summary
- allow `--custom-context` argument to be passed through to commands like `/review_architecture_debug`

## Testing
- `pre-commit run --files pr_agent/algo/utils.py` *(fails: command not found)*
- `pytest -v tests/unittest` *(fails: ModuleNotFoundError: No module named 'pr_agent')*

------
https://chatgpt.com/codex/tasks/task_e_68725bf23be4833184fb1efd79b2a308