### PR TITLE
Enhance /check_ticket with AI validation

### DIFF
--- a/docs/docs/tools/check_ticket.md
+++ b/docs/docs/tools/check_ticket.md
@@ -1,9 +1,9 @@
 ## Overview
 
 The `/check_ticket` tool analyses the latest commit message for a ticket ID in the form `module: 0224008: [BUGS]`.
-If a ticket ID is found, it queries the configured bug tracker for that ticket and checks whether the commit modifies the lines mentioned in the ticket description.
+If a ticket ID is found, it queries the configured bug tracker for that ticket and then uses an AI model to decide whether the commit fixes the described problem. The ticket description and the commit diff are provided to the model, which returns a short verdict.
 
-If the relevant lines are changed, the tool comments that the ticket problem was resolved; otherwise it notes that the ticket was not addressed.
+If the model determines that the issue is fixed, the tool comments that the ticket problem was resolved; otherwise it notes that the ticket was not addressed.
 
 ```toml
 /check_ticket

--- a/pr_agent/config_loader.py
+++ b/pr_agent/config_loader.py
@@ -25,6 +25,7 @@ global_settings = Dynaconf(
         "settings/code_suggestions/pr_code_suggestions_reflect_prompts.toml",
         "settings/pr_information_from_user_prompts.toml",
         "settings/pr_update_changelog_prompts.toml",
+        "settings/pr_check_ticket_prompts.toml",
         "settings/pr_custom_labels.toml",
         "settings/pr_add_docs.toml",
         "settings/custom_labels.toml",

--- a/pr_agent/settings/pr_check_ticket_prompts.toml
+++ b/pr_agent/settings/pr_check_ticket_prompts.toml
@@ -1,0 +1,21 @@
+[pr_check_ticket_prompt]
+system="""You are TicketValidator, an AI assistant that determines whether a commit fixes the problem described in a bug ticket."""
+user="""Ticket Description:
+======
+{{ ticket_description|trim }}
+======
+
+Commit Message:
+======
+{{ commit_message|trim }}
+======
+
+Commit Diff:
+======
+{{ diff|trim }}
+======
+
+Respond in YAML with two fields:
+  solved: yes or no
+  explanation: short reasoning
+"""

--- a/tests/unittest/test_check_ticket_ai.py
+++ b/tests/unittest/test_check_ticket_ai.py
@@ -1,0 +1,78 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from pr_agent.tools.check_ticket import PRCheckTicket
+
+
+@pytest.fixture(autouse=True)
+def bugtracker_env(monkeypatch):
+    monkeypatch.setenv("BUGTRACKER_URL", "https://bugs")
+
+
+@pytest.fixture
+def mock_git_provider():
+    provider = MagicMock()
+    provider.get_commit_messages.return_value = "core: 123: fix bug"
+    provider.publish_comment = MagicMock()
+    provider.get_pr_id.return_value = 1
+    provider.pr = MagicMock()
+    provider.pr.title = "t"
+    return provider
+
+
+@pytest.fixture
+def mock_ai_handler():
+    handler = MagicMock()
+    handler.chat_completion = AsyncMock(return_value=("solved: true", "stop"))
+    return handler
+
+
+@pytest.mark.asyncio
+async def test_check_ticket_ai_solved(mock_git_provider, mock_ai_handler):
+    with patch("pr_agent.tools.check_ticket.get_git_provider", return_value=lambda url: mock_git_provider), \
+         patch("pr_agent.tools.check_ticket.get_pr_diff", return_value="diff"), \
+         patch("pr_agent.tools.check_ticket.requests.get") as mock_req, \
+         patch("pr_agent.tools.check_ticket.get_settings") as mock_settings:
+
+        resp = MagicMock()
+        resp.json.return_value = {"description": "bug"}
+        mock_req.return_value = resp
+
+        mock_settings.return_value.pr_check_ticket_prompt.system = "sys"
+        mock_settings.return_value.pr_check_ticket_prompt.user = "user"
+        mock_settings.return_value.config.model = "gpt"
+        mock_settings.return_value.config.temperature = 0.0
+        mock_settings.return_value.config.publish_output = True
+
+        tool = PRCheckTicket("url", ai_handler=lambda: mock_ai_handler)
+        msg = await tool.run()
+
+        assert "решена" in msg
+        mock_git_provider.publish_comment.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_check_ticket_ai_not_solved(mock_git_provider, mock_ai_handler):
+    mock_ai_handler.chat_completion = AsyncMock(return_value=("solved: false", "stop"))
+    with patch("pr_agent.tools.check_ticket.get_git_provider", return_value=lambda url: mock_git_provider), \
+         patch("pr_agent.tools.check_ticket.get_pr_diff", return_value="diff"), \
+         patch("pr_agent.tools.check_ticket.requests.get") as mock_req, \
+         patch("pr_agent.tools.check_ticket.get_settings") as mock_settings:
+
+        resp = MagicMock()
+        resp.json.return_value = {"description": "bug"}
+        mock_req.return_value = resp
+
+        mock_settings.return_value.pr_check_ticket_prompt.system = "sys"
+        mock_settings.return_value.pr_check_ticket_prompt.user = "user"
+        mock_settings.return_value.config.model = "gpt"
+        mock_settings.return_value.config.temperature = 0.0
+        mock_settings.return_value.config.publish_output = True
+
+        tool = PRCheckTicket("url", ai_handler=lambda: mock_ai_handler)
+        msg = await tool.run()
+
+        assert "не решена" in msg
+        mock_git_provider.publish_comment.assert_called_once()
+


### PR DESCRIPTION
## Summary
- add AI prompt for ticket verification
- integrate new AI logic in `PRCheckTicket`
- load prompt via configuration
- update documentation for `/check_ticket`
- add unit tests
- fix missing typing import

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -v tests/unittest/test_check_ticket_ai.py` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_68727e681bf8833188e06081a594ab03